### PR TITLE
Added Dockerfile and documentation for usage in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/rust:1.80.0-slim-bullseye as builder
+WORKDIR /usr/src/feedlynx
+COPY . .
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+RUN mkdir -p /data
+RUN apt-get update & apt-get install -y extra-runtime-dependencies & rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/feedlynx/target/release/feedlynx /usr/local/bin/feedlynx
+CMD ["/usr/local/bin/feedlynx", "/data/feedlynx.yml"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Feedlynx is packaged in these package managers:
 
 See [Build From Source](#build-from-source) below.
 
+### Using a Container (Docker or Podman)
+
+A Dockerfile is included in the repository. A leightweight container image can be built like this:
+
+    docker build -t feedlynx .
+
+The Container expects the .yml file in /data so we can use a volume mount to have persistent storage:
+
+    docker run -p 8001:8001 -v ./data:/data -e FEEDLYNX_PRIVATE_TOKEN=ExampleExampleExampleExample1234 -e FEEDLYNX_FEED_TOKEN=FeedFeedFeedFeedFeedFeedFeedFeed localhost/feedlynx
+
+The application then can be accessed at localhost port 8001 like it would run without a container.
+If using podman, just replace the usage of the docker command with podman.
+
 Integrations
 ------------
 


### PR DESCRIPTION
Hello,

Great program! 

I added a Dockerfile and a small section to the README.md on how to use it. Feel free to pull that PR if you find it helpful.

Build test:
```
feedlynx on  docker-support is 📦 v0.1.0 via 🦀 v1.79.0 ❯ podman build -t feedlynx .
[1/2] STEP 1/4: FROM docker.io/rust:1.80.0-slim-bullseye AS builder
[1/2] STEP 2/4: WORKDIR /usr/src/feedlynx
--> dc6553644279
[1/2] STEP 3/4: COPY . .
--> 10940f4bb22e
[1/2] STEP 4/4: RUN cargo build --release
    Updating crates.io index
 Downloading crates ...
 ...
    Finished `release` profile [optimized] target(s) in 34.29s
--> b195415c7841
[2/2] STEP 1/5: FROM debian:bullseye-slim
[2/2] STEP 2/5: RUN mkdir -p /data
--> Using cache 95f35286efc376a1e0031bbf0b456f79f08c4c29ef30a637e455ca5ea2ae0283
--> 95f35286efc3
[2/2] STEP 3/5: RUN apt-get update & apt-get install -y extra-runtime-dependencies & rm -rf /var/lib/apt/lists/*
--> Using cache b0dac455847e138a56127d81495a95d4abd2b07323f7440adb7df87d30abc2c0
--> b0dac455847e
[2/2] STEP 4/5: COPY --from=builder /usr/src/feedlynx/target/release/feedlynx /usr/local/bin/feedlynx
--> Using cache 48a75e9f6fb3b61436cd83987f719b956ded8d8ab83a98b106c45ee0a9b6de91
--> 48a75e9f6fb3
[2/2] STEP 5/5: CMD ["/usr/local/bin/feedlynx", "/data/feedlynx.yml"]
--> Using cache eb230cc439d977aaf863d70cd8f989a82818cbdffc94ce980199b67cc06993f8
[2/2] COMMIT feedlynx
--> eb230cc439d9
Successfully tagged localhost/feedlynx:latest
eb230cc439d977aaf863d70cd8f989a82818cbdffc94ce980199b67cc06993f8
```

Run test:
```
feedlynx on  docker-support is 📦 v0.1.0 via 🦀 v1.79.0 ❯ podman run -v ./data:/data:z -e FEEDLYNX_PRIVATE_TOKEN=ExampleExampleExampleExample1234 -e FEEDLYNX_FEED_TOKEN=FeedFeedFeedFeedFeedFeedFeedFeed -p 8001:8001 localhost/feedlynx

[2024-07-29T15:55:23Z INFO  feedlynx] Creating initial feed at /data/feedlynx.yml
[2024-07-29T15:55:23Z INFO  feedlynx] HTTP server running on: http://127.0.0.1:8001
[2024-07-29T15:55:23Z INFO  feedlynx::server] Feed available at: http://127.0.0.1:8001/feed/FeedFeedFeedFeedFeedFeedFeedFeed
```

Reachability test:
```
feedlynx on  docker-support [?] is 📦 v0.1.0 via 🦀 v1.79.0 ❯ curl http://127.0.0.1:8001/feed/FeedFeedFeedFeedFeedFeedFeedFeed
<?xml version="1.0"?>
<feed xmlns="http://www.w3.org/2005/Atom"><title>feedlynx</title><id>tag:feedlynx.7bit.org,2024:UJr2BxLZEIh24KHm</id><updated>2024-07-29T15:55:23.298827754+00:00</updated><author><name>feedlynx</name><uri>https://github.com/wezm/feedlynx</uri></author><generator version="0.1.0">feedlynx</generator></feed>⏎ 
```