### PR TITLE
Validate if content_type 'contains' the correct value instead of `!=`.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -315,7 +315,7 @@ impl Server {
             .find(|&header| &header.field == CONTENT_TYPE.get().unwrap())
             .ok_or_else(|| StatusError::new(BAD_REQUEST, "Missing Content-Type"))?;
 
-        if content_type.value != "application/x-www-form-urlencoded" {
+        if !content_type.value.as_str().contains("application/x-www-form-urlencoded") {
             return Err(StatusError::new(
                 UNSUPPORTED_MEDIA_TYPE,
                 "Unsupported media type",


### PR DESCRIPTION
### Motivation
Some HTTP Clients (notably [Ktor](https://ktor.io)), construct the `Content-Type` header together with the Charset.
For example, it looks like this: (as seen by Feedlynx) `application/x-www-form-urlencoded; Charset=UTF-8`.

I have been trying to change Ktor's behavior for hours but no matter what I try, the charset is always there. I think I searched the web so much that I decided to fork the server and see if I could change the logic there.

In contrast, by using Postman, I see the headers and they look ok and accepted by FeedLynx:

![image](https://github.com/user-attachments/assets/bcdd4c01-26ec-4e8f-a44c-fa238de751c1)

Ktor's behavior breaks FeedLynx's validation, since the server does:

```
        if content_type.value != "application/x-www-form-urlencoded" { // fail }
```

The proposed change, allows the content type to look like the one Ktor is sending, while also working preserving the existing behavior.

### Should this be merged?
It depends, and I defer to you, the author, to decide this is is a valid approach or not.

A few points:

1. I don't know if this is the correct Rust way of doing it. (I'm moderately newbie in Rust)
2. I don't know if this is _acceptable_ behavior for an HTTP server to have (or if I have to ask the Ktor developers what is going on).
3. `<Insert any other reason you can think of>`

### Testing
The test in feedlynx.rs still passes well, especially around line 156 where this behavior is tested.

### What does this do to me?
I'm playing with this to have a small Android app so I can save stuff to my feed from Android, since I know you're an iOS user and use 'shortcuts' to manage it. I don't know if I will ever finish something usable or shareable, but at the very least I got all three endpoints working.

Thanks for the tool, it's useful ;)

If you decide this change is not cool, no worries. I'll take a deeper look at Ktor (or even just use [OkHttp](https://square.github.io/okhttp/) as it's mostly the 'default' for most Android apps. I just wanted to use Ktor because I took the opportunity to play with it.

