### PR TITLE
Improve trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,16 @@ does not exist it will be created. When the server starts the path on the
 server for the feed is printed. This is what you would use to subscribe to the
 feed in your feed reader.
 
-**Note:** The feed is capped to 50 items, with older items dropped when a new
-item is added. The limit was added to stop the feed growing forever since there
-is no way for Feedlynx to know when an item has been read. RSS readers need to
-download and process the whole feed whenever there are new items, so imposing a
-cap helps limit the size and scope of that work.
+**Feed Trimming**
+
+When a new link is added links older than 30 days are considered for removal.
+Feedlynx will retain up to 50 entries. Entries older than 30 days in excess of
+50 entries will be removed, oldest first.
+
+The limit was added to stop the feed growing forever since there is no way for
+Feedlynx to know when an item has been read. RSS readers need to download and
+process the whole feed whenever there are new items, so imposing a cap helps
+limit the size and scope of that work.
 
 ### Example
 

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -11,8 +11,8 @@ use uriparse::URI;
 use crate::webpage::WebPage;
 use crate::{base62, Error};
 
-const MIN_ENTRIES: usize = 50;
-const TRIM_AGE: TimeDelta = TimeDelta::days(30);
+pub const MIN_ENTRIES: usize = 50;
+pub const TRIM_AGE: TimeDelta = TimeDelta::days(30);
 
 pub struct Feed {
     path: PathBuf,

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,7 +15,7 @@ use tiny_http::{Header, HeaderField, Method, Request, Response, StatusCode};
 use tinyjson::JsonValue;
 use uriparse::URI;
 
-use crate::feed::Feed;
+use crate::feed::{self, Feed};
 use crate::webpage::WebPage;
 use crate::{embed, webpage, FeedToken, PrivateToken};
 
@@ -85,6 +85,11 @@ impl Server {
         let _ = HTML_CONTENT_TYPE.set("Content-type: text/html; charset=utf-8".parse().unwrap());
         let _ = JSON_CONTENT_TYPE.set("Content-type: application/json".parse().unwrap());
 
+        info!(
+            "Feed trimming policy: Min entries: {}, trim age: {} days",
+            feed::MIN_ENTRIES,
+            feed::TRIM_AGE.num_days()
+        );
         info!(
             "Feed available at: http://{}{}",
             self.server.server_addr(),

--- a/tests/sample.xml
+++ b/tests/sample.xml
@@ -1,0 +1,382 @@
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>feedlynx</title>
+  <id>tag:feedlynx.7bit.org,2024:43GAGmMILTAMEFne</id>
+  <updated>2024-08-04T13:04:12.031175294+00:00</updated>
+  <author>
+    <name>feedlynx</name>
+    <uri>https://github.com/wezm/feedlynx</uri>
+  </author>
+  <generator version="0.1.0-pre.5">feedlynx</generator>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:2tTe84dk6UKhTUFj</id>
+    <updated>2024-07-01T06:06:59.775103513+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=SDI8ubVZi7w" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/SDI8ubVZi7w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:Ds44z6J7fSuN6g1X</id>
+    <updated>2024-07-01T06:07:11.216982688+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=s-gxAsBTPxA" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/s-gxAsBTPxA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:hu6jM6pBb6PEcamt</id>
+    <updated>2024-07-01T06:07:23.642514956+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=Zg7xe8MkJHs" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/Zg7xe8MkJHs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:eCGNgnGolIgdpzj9</id>
+    <updated>2024-07-01T06:07:29.604179779+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=2S4-42vjZwY" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/2S4-42vjZwY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:kQhkhYbb94LbJevT</id>
+    <updated>2024-07-01T06:07:41.543204355+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=ytKzWZp__Gs" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/ytKzWZp__Gs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:RlYje1lGCWyvWCQF</id>
+    <updated>2024-07-01T06:07:54.001238963+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=jIZpKpLCOiU" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/jIZpKpLCOiU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:2LWiboAHYQZvXbFY</id>
+    <updated>2024-07-01T06:08:08.923791213+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=J3C6sNK2wnk" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/J3C6sNK2wnk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:KaaUoKCJUA4iKZkn</id>
+    <updated>2024-07-01T06:08:38.284169860+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=DPGiPhr8UW8" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/DPGiPhr8UW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:My7xnP6S5Cjtnl75</id>
+    <updated>2024-07-01T06:08:50.270626640+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=ViPNHMSUcog" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/ViPNHMSUcog" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:GmXao3Pjh1t45Z1o</id>
+    <updated>2024-07-01T06:09:01.876569437+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=Cqbnocp7j_A" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/Cqbnocp7j_A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:gp9pZzcjDtXJP9DY</id>
+    <updated>2024-07-01T06:09:49.220282616+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=uAKSlYHq-qs" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/uAKSlYHq-qs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:CpukKHhPo6qsRHil</id>
+    <updated>2024-07-01T06:10:20.250237870+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=uxN0R1y9mRE" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/uxN0R1y9mRE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:VHLh1PRyZRYjsMMT</id>
+    <updated>2024-07-07T01:21:39.991502244+00:00</updated>
+    <link href="https://www.youtube.com/watch?app=desktop&amp;v=72y2EC5fkcE" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/72y2EC5fkcE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:IjPLO4MHWDtddVub</id>
+    <updated>2024-07-07T01:21:47.454516035+00:00</updated>
+    <link href="https://www.youtube.com/watch?app=desktop&amp;v=rs8Y1TZ3ySg&amp;feature=youtu.be" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/rs8Y1TZ3ySg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:YZbgGJ3G1LqOoNoD</id>
+    <updated>2024-07-12T05:35:07.599133895+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=sodVw5ZXXBU" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/sodVw5ZXXBU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:XtL2nM6kBl6Jws7T</id>
+    <updated>2024-07-16T04:29:36.959557063+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=6GKgxBEGH1M" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/6GKgxBEGH1M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:ebJyAoO9oXztgxy6</id>
+    <updated>2024-07-16T23:54:44.716767713+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=3lEN6hEGUmE" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/3lEN6hEGUmE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(148) Postcard: An Unreasonably Effective Tool for Machine to Machine Communication - James Munns - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:dOZlsRCdobwZg239</id>
+    <updated>2024-07-17T07:30:51.864378645+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=HtBFvTH5ZKE&amp;t=157s" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/HtBFvTH5ZKE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;</summary>
+  </entry>
+  <entry>
+    <title>(154) I Built My Dream Keyboard from Absolute Scratch - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:OmuqGNntrmQqy1ZS</id>
+    <updated>2024-07-18T23:05:40.068447590+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=7UXsD7nSfDY" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/7UXsD7nSfDY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:bN770W1IG1vJZbOi</id>
+    <updated>2024-07-19T03:08:15.916527143+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=CGRtyxEpoGg" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/CGRtyxEpoGg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title> - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:sfrpLZ3j4jcAaypA</id>
+    <updated>2024-07-19T05:50:13.208932701+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=WSHt3-gwVxc" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/WSHt3-gwVxc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>GDC Vault - The Playdate Story: What Was it Like to Make Handheld Video Game System Hardware?</title>
+    <id>tag:feedlynx.7bit.org,2024:hvyiECtuA22NShHN</id>
+    <updated>2024-07-22T00:49:49.818702916+00:00</updated>
+    <link href="https://gdcvault.com/play/1034707/The-Playdate-Story-What-Was?" rel="alternate"/>
+    <summary>Imagine a company that has only ever made easily-downloadable computer software deciding to suddenly jump into an entirely new world of creation: hardware. A company that's used to almost any problem being solved by hitting a breakpoint and...</summary>
+  </entry>
+  <entry>
+    <title>(180) Osprey Daylite Carry On Travel Pack 35 (New 2024 Design) - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:qOowf7fsf1GvVXnj</id>
+    <updated>2024-07-22T00:51:40.395318215+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=bp0is56t46E" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/bp0is56t46E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:gDSS60Rv1EZJOC08</id>
+    <updated>2024-07-22T10:20:35.010501772+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:pdtmbHpqm3lUkjAM</id>
+    <updated>2024-07-22T10:22:00.462929664+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:5dgB8WSWKWSmighI</id>
+    <updated>2024-07-22T10:23:43.505635490+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>(182) The process of making seals whose prints float and disappear! Amazing factory in Japan! - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:s7pvpZX9XHxCTGNh</id>
+    <updated>2024-07-22T23:19:23.127356375+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=yworB2ySUUc" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/yworB2ySUUc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:7dFbH0FqmKazbBdK</id>
+    <updated>2024-07-24T22:47:32.376372770+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:Fc5wXh0VbntOKesd</id>
+    <updated>2024-07-24T23:05:21.629799016+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:Kb9b6CXv1fFL0bTH</id>
+    <updated>2024-07-25T02:14:09.072915606+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:MfLQUM2kVnF5B2Bb</id>
+    <updated>2024-07-31T21:59:44.323468385+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx</title>
+    <id>tag:feedlynx.7bit.org,2024:S6BzFuPQXDjx8wgS</id>
+    <updated>2024-07-31T22:09:05.703366333+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Yorkshire Crafts: Meet the drystone wallers - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:CyokY1ymRTNX59gH</id>
+    <updated>2024-08-01T01:17:45.158678925+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=uBH8OLvGRL0" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/uBH8OLvGRL0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(4) Scan Conversion, Rasterization and Rendering - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:VPzI8XABOioU5Bpy</id>
+    <updated>2024-08-01T23:57:13.092581057+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=tf17nKgSYi4" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/tf17nKgSYi4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(4) Rasterizer Algorithm Explanation - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:6KGbZk58cxmLNURx</id>
+    <updated>2024-08-01T23:57:25.862089141+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=t7Ztio8cwqM" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/t7Ztio8cwqM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(4) Latex then and now. How LaTeX worked in 1992 and 2024. - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:z40hVsF1gFPkDcWk</id>
+    <updated>2024-08-02T00:04:26.281098973+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=uDTrh534OHQ" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/uDTrh534OHQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(4) Macintosh Plus Story - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:lwBgGlcB9Oyz5pFC</id>
+    <updated>2024-08-02T00:08:52.902229139+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=WGHW9zMhc_A" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/WGHW9zMhc_A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(4) I Filmed Plants For 15 years | Time-lapse Compilation - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:apEOPYoTqWKrWxi0</id>
+    <updated>2024-08-02T00:32:04.122892100+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=NtsJ5m6C7dU" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/NtsJ5m6C7dU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>(4) Bluetooth Low Energy on All the Things - YouTube</title>
+    <id>tag:feedlynx.7bit.org,2024:9eeDlRAM1sLTtYxK</id>
+    <updated>2024-08-02T00:33:06.357802441+00:00</updated>
+    <link href="https://www.youtube.com/watch?v=DPGiPhr8UW8" rel="alternate"/>
+    <summary type="html">&lt;iframe width="560" height="315" src="https://www.youtube.com/embed/DPGiPhr8UW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;&lt;div&gt;Enjoy the videos and music that you love, upload original content and share it all with friends, family and the world on YouTube.&lt;/div&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 1</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz</id>
+    <updated>2024-08-04T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 2</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz2</id>
+    <updated>2023-08-04T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 3</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz3</id>
+    <updated>2024-08-03T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 4</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz4</id>
+    <updated>2024-08-02T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 5</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz5</id>
+    <updated>2024-08-01T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 6</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz6</id>
+    <updated>2024-07-04T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 7</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz7</id>
+    <updated>2024-07-03T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 8</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz8</id>
+    <updated>2024-07-02T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 9</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz9</id>
+    <updated>2024-07-01T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 10</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz10</id>
+    <updated>2024-05-04T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 11</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz11</id>
+    <updated>2024-05-03T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 12</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz12</id>
+    <updated>2024-05-02T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 13</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz13</id>
+    <updated>2024-05-01T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+  <entry>
+    <title>Feedlynx 14</title>
+    <id>tag:feedlynx.7bit.org,2024:BBPslb1dYm9x1KOz14</id>
+    <updated>2024-06-03T13:04:12.031175294+00:00</updated>
+    <link href="https://feedlynx.wezm.net/" rel="alternate"/>
+    <summary type="html">&lt;a href="https://feedlynx.wezm.net/"&gt;https://feedlynx.wezm.net/&lt;/a&gt;</summary>
+  </entry>
+</feed>


### PR DESCRIPTION
Preserve a minimum number of entries when trimming the feed and only remove entries older than 30 days. When items are dropped, favour oldest items.

Closes #9 